### PR TITLE
Add simple location website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# app
+# Location App
+
+Open `index.html` in a web browser. The page uses [ipapi.co](https://ipapi.co/) to display your current city and country based on your IP address.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your Location</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+  </style>
+</head>
+<body>
+  <h1>Your Location</h1>
+  <p id="location">Loading...</p>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      fetch('https://ipapi.co/json/')
+        .then(function(response) { return response.json(); })
+        .then(function(data) {
+          var loc = document.getElementById('location');
+          if (data && data.city && data.country_name) {
+            loc.textContent = 'You are in ' + data.city + ', ' + data.country_name + '.';
+          } else {
+            loc.textContent = 'Unable to determine your location.';
+          }
+        })
+        .catch(function() {
+          document.getElementById('location').textContent = 'Unable to determine your location.';
+        });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` page using ipapi.co to show the visitor's location
- update README with instructions

## Testing
- `curl -L https://ipapi.co/json`

------
https://chatgpt.com/codex/tasks/task_e_688bb2092f8c832aacd42a33ae1c1914